### PR TITLE
결제기록 페이지 UX 개선

### DIFF
--- a/lib/app/pages/history/page.dart
+++ b/lib/app/pages/history/page.dart
@@ -99,10 +99,6 @@ class TransactionGroup extends StatelessWidget {
               '${date.month}월 ${date.day}일',
               style: DPTextTheme.REGULAR,
             ),
-            Text(
-              '$sum원',
-              style: DPTextTheme.REGULAR_IMPORTANT,
-            ),
           ],
         ),
         const SizedBox(height: 24),

--- a/lib/app/pages/history/page.dart
+++ b/lib/app/pages/history/page.dart
@@ -22,7 +22,7 @@ class HistoryPage extends GetView<HistoryPageController> {
     for (var dailyTransaction in dailyTransactions.entries) {
       children.add(TransactionGroup(date: dailyTransaction.key, transactions: dailyTransaction.value));
     }
-    children.sort((a, b) => a.date.compareTo(b.date));
+    children.sort((a, b) => b.date.compareTo(a.date));
     return Column(children: children);
   }
 


### PR DESCRIPTION
결제 기록 페이지의 UX를 개선하였습니다.

- 일별로 사용한 금액을 보여주지 않음
- 결제 기록을 날짜 내림차순으로 정렬