### PR TITLE
fix: kakaotalk chat link

### DIFF
--- a/lib/app/pages/pin/page.dart
+++ b/lib/app/pages/pin/page.dart
@@ -238,7 +238,7 @@ class PinPage extends GetView<PinPageController> {
                     Obx(() {
                       if (controller.isPinLocked.value) {
                         return GestureDetector(
-                          onTap: () => launchUrl(Uri.parse('http://pf.kakao.com/_Rxanxlxj/chat')),
+                          onTap: () => launchUrl(Uri.parse('http://pf.kakao.com/_gHxlCxj/chat')),
                           child: const Text(
                             '핀 복구하기',
                             style: TextStyle(fontFamily: 'Pretendard', fontWeight: FontWeight.w600, fontSize: 16, height: 1.2, color: DPColors.MAIN_THEME, decoration: TextDecoration.underline),


### PR DESCRIPTION
핀 입력 화면에서는 카카오톡 채널 링크로 작동하지 않는 링크를 사용하고 있습니다.
유저 페이지에 있는 채널 id를 대신 사용했습니다.